### PR TITLE
chore(doc): Add a simple example

### DIFF
--- a/examples/.terraform-docs.yaml
+++ b/examples/.terraform-docs.yaml
@@ -1,0 +1,39 @@
+formatter: "markdown table"
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+
+sections:
+  hide:
+    - outputs
+    - inputs
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  anchor: true
+  default: true
+  escape: false
+  hide-empty: true
+  html: false
+  indent: 2
+  required: true
+  sensitive: true
+  type: true

--- a/examples/generate_random/README.md
+++ b/examples/generate_random/README.md
@@ -1,0 +1,49 @@
+# Simple domain
+
+This example shows how to generate a random password and store it into Scaleway Secrets Manager.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+To get the random password, type the following command:
+
+```bash
+$ jq -r .outputs.secret.value terraform.tfstate
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13 |
+| <a name="requirement_random"></a> [random](#requirement_random) | 3.5.1 |
+| <a name="requirement_scaleway"></a> [scaleway](#requirement_scaleway) | ~> 2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_random"></a> [random](#provider_random) | 3.5.1 |
+| <a name="provider_scaleway"></a> [scaleway](#provider_scaleway) | 2.17.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_secret"></a> [secret](#module_secret) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [random_password.password](https://registry.terraform.io/providers/hashicorp/random/3.5.1/docs/resources/password) | resource |
+| [scaleway_account_project.default](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/account_project) | data source |
+<!-- END_TF_DOCS -->

--- a/examples/generate_random/main.tf
+++ b/examples/generate_random/main.tf
@@ -1,0 +1,31 @@
+provider "scaleway" {
+}
+
+provider "random" {
+}
+
+data "scaleway_account_project" "default" {
+  name = "default"
+}
+
+locals {
+  region             = "pl-waw"
+  secret_description = "Example secret"
+  secret_name        = "example-secret"
+}
+
+resource "random_password" "password" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+module "secret" {
+  source = "../.."
+
+  name        = local.secret_name
+  data        = random_password.password.result
+  description = local.secret_description
+  project_id  = data.scaleway_account_project.default.id
+  region      = local.region
+}

--- a/examples/generate_random/outputs.tf
+++ b/examples/generate_random/outputs.tf
@@ -1,0 +1,12 @@
+output "secret_status" {
+  value = module.secret.secret_status
+}
+
+output "version_status" {
+  value = module.secret.version_status
+}
+
+output "secret" {
+  value     = module.secret.version_data
+  sensitive = true
+}

--- a/examples/generate_random/versions.tf
+++ b/examples/generate_random/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.5.1"
+    }
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2"
+    }
+  }
+}


### PR DESCRIPTION
Add an example that shows how to generate a random password and store it in Scaleway Secrets Manager.